### PR TITLE
Added support to install dependencies using most common package managers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ elif [ "$ID_LIKE" = "opensuse suse" ];then
     package_manager="zypper install"
 fi
 
-echo $package_manager cmake extra-cmake-modules
+sudo $package_manager cmake extra-cmake-modules
 
 mkdir -p ~/.config/krunnercrypto
 cp config/config.json ~/.config/krunnercrypto

--- a/install.sh
+++ b/install.sh
@@ -3,19 +3,23 @@
 # Exit if something fails
 set -e
 
-declare -A osInfo;
-osInfo[/etc/debian_version]="apt-get install"
-osInfo[/etc/fedora-release]="dnf install"
-osInfo[/etc/arch-release]="pacman -S"
+if [ -e /etc/os-release ]; then
+   . /etc/os-release
+else
+   . /usr/lib/os-release
+fi
 
-for f in ${!osInfo[@]}
-do
-    if [[ -f $f ]];then
-        package_manager=${osInfo[$f]}
-    fi
-done
+if [ "$ID_LIKE" = "arch" ];then
+    package_manager="pacman -S"
+elif [ "$ID_LIKE" = "debain" ];then
+    package_manager="apt-get install"
+elif [ "$ID" = "fedora" ];then
+    package_manager="dnf install"
+elif [ "$ID_LIKE" = "opensuse suse" ];then
+    package_manager="zypper install"
+fi
 
-sudo $package_manager cmake extra-cmake-modules
+echo $package_manager cmake extra-cmake-modules
 
 mkdir -p ~/.config/krunnercrypto
 cp config/config.json ~/.config/krunnercrypto

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,20 @@
 # Exit if something fails
 set -e
 
+declare -A osInfo;
+osInfo[/etc/debian_version]="apt-get install"
+osInfo[/etc/fedora-release]="dnf install"
+osInfo[/etc/arch-release]="pacman -S"
+
+for f in ${!osInfo[@]}
+do
+    if [[ -f $f ]];then
+        package_manager=${osInfo[$f]}
+    fi
+done
+
+sudo $package_manager cmake extra-cmake-modules
+
 mkdir -p ~/.config/krunnercrypto
 cp config/config.json ~/.config/krunnercrypto
 


### PR DESCRIPTION
Added support to auto install dependencies using:
> pacman
> apt
> dnf
> zypper

With identifiers for most common distros:
> debian based
> arch based
> fedora
> opensuse

Sorry for crowding your pull requests. New pull request opened cause I forgot to edit out the debug step and put in the final command, oops :P 